### PR TITLE
[UPD] Support relative path deployment

### DIFF
--- a/src/mail_devel/resources/index.html
+++ b/src/mail_devel/resources/index.html
@@ -5,8 +5,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>mail-devel</title>
-  <script type="text/javascript" src="/main.js"></script>
-  <link type="text/css" rel="stylesheet" href="/main.css"/>
+  <script type="text/javascript" src="main.js"></script>
+  <link type="text/css" rel="stylesheet" href="main.css"/>
 </head>
 
 <body>

--- a/src/mail_devel/resources/main.js
+++ b/src/mail_devel/resources/main.js
@@ -127,7 +127,7 @@ class MailClient {
       return;
 
     const proto = (window.location.protocol === "https:") ? "wss:" : "ws:";
-    const url = `${proto}//${window.location.host}/websocket`;
+    const url = `${proto}//${window.location.host}${window.location.pathname}websocket`;
     this.socket = new WebSocket(url);
 
     const self = this;


### PR DESCRIPTION
This supports relative path deployment using for example:

```
    location ~* ^/maildevel/(.*) {
      proxy_pass http://localhost:24080/$1$is_args$args;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header Host $host;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

      # WebSocket support
      proxy_http_version 1.1;
      proxy_set_header Upgrade $http_upgrade;
      proxy_set_header Connection "upgrade";
    }
```

